### PR TITLE
Safely handle invalid embed

### DIFF
--- a/bin/sky-tumblr-export
+++ b/bin/sky-tumblr-export
@@ -241,7 +241,7 @@ function outputPost (post, next) {
       break;
     case "video":
       post.title = S(post.caption).stripTags().s
-      post.body =  post.player[post.player.length - 1].embed_code
+      post.body =  post.player[post.player.length - 1].embed_code || ''
       post.format = 'html'
       break;
     case "quote":


### PR DESCRIPTION
If `post.player[post.player.length - 1].embed_code === false`, set `post.body` to empty string instead, keeping *pandoc* from throwing error.

I noticed on a few of my posts that I had `false` set for all of the `embed_code` values.

When `post.body` was passed into *pandoc* as `false`, *pandoc* would throw an error.

This isn't the most elegant solution, admittedly.  

